### PR TITLE
Upgrade Hugo version from 0.110.0 to 0.152.2

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Hugo  🛠️
       uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2
       with:
-        hugo-version: '0.110.0'
+        hugo-version: '0.152.2'
 
 
     - name: Install action Go Deps 🌎


### PR DESCRIPTION
## Summary
Updates the Hugo version used in the GitHub Actions workflow to a newer release.

## Changes
- Bumped Hugo version from `0.110.0` to `0.152.2` in the Hugo installation step of the CI/CD workflow

## Details
This upgrade brings Hugo to a more recent version with bug fixes, performance improvements, and new features that may be available in the 0.152.2 release.

https://claude.ai/code/session_01E6Hi8FdLUjeWGBUxWmjm4R